### PR TITLE
Use Triggers in options for ethics icons

### DIFF
--- a/events/anomaly_events_ladybugs.txt
+++ b/events/anomaly_events_ladybugs.txt
@@ -68,28 +68,56 @@ ship_event = {
 		}
 	}
 	option = {
-		exclusive_trigger = { ownerHasSpiritualistEthic = yes }
+		exclusive_trigger = {
+			owner = {
+				OR = {
+					has_ethic = "ethic_spiritualist"
+					has_ethic = "ethic_fanatic_spiritualist"
+				}
+			}
+		}
 		name = ladybugs.spiritualist.option
 		FROM = {
 			set_deposit = d_zro_deposit_1
 		}
 	}
 	option = {
-		exclusive_trigger = { ownerHasMaterialistEthic = yes }
+		exclusive_trigger = {
+			owner = {
+				OR = {
+					has_ethic = "ethic_materialist"
+					has_ethic = "ethic_fanatic_materialist"
+				}
+			}
+		}
 		name = ladybugs.materialist.option
 		FROM = {
 			set_deposit = d_zro_deposit_1
 		}
 	}
 	option = {
-		exclusive_trigger = { ownerHasXenophileEthic = yes }
+		exclusive_trigger = {
+			owner = {
+				OR = {
+					has_ethic = "ethic_xenophile"
+					has_ethic = "ethic_fanatic_xenophile"
+				}
+			}
+		}
 		name = ladybugs.xenophile.option
 		FROM = {
 			set_deposit = d_zro_deposit_1
 		}
 	}
 	option = {
-		exclusive_trigger = { ownerHasXenophobeEthic = yes }
+		exclusive_trigger = {
+			owner = {
+				OR = {
+					has_ethic = "ethic_xenophobe"
+					has_ethic = "ethic_fanatic_xenophobe"
+				}
+			}
+		}
 		name = ladybugs.xenophobe.option
 		FROM = {
 			set_deposit = d_zro_deposit_1


### PR DESCRIPTION
Wasn't able to get gestalt icons automatically.  Going to ignore that for now.

If we use the options like this, the engine picks up the event option and automatically adds the correct ethics icons.

